### PR TITLE
save 1 byte initializing DS and CX

### DIFF
--- a/snake.asm
+++ b/snake.asm
@@ -1,7 +1,6 @@
-push 0xB800
-pop ds
-mov cx, 0xFA0
 std
+lds cx, [si+4]
+mov al, [0xf]
 start:
 	mov ax, 0x3
 	int 0x10

--- a/snake.asm
+++ b/snake.asm
@@ -1,6 +1,6 @@
 std
-lds cx, [si+4]
-mov al, [0xf]
+lds cx, [si+0x4]
+mov al, [0xF]
 start:
 	mov ax, 0x3
 	int 0x10


### PR DESCRIPTION
If you're willing to assume SI is 0x100 at program start (which it is on most DOS versions according to http://www.fysnet.net/yourhelp.htm) this saves 1 byte.
```
mov al, [0xf]
mov ax, 3
```
is assembled into `a0 0f 00 b8 03 00` which is used to initialize DS and CX