### PR TITLE
Let main.sh also work on macOS + switch from lighttpd to Algernon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-snake.com
+*.bak
+*.com
+*.log
+*.o
+*.swp
+*.tmp
+*.zip

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to test the code yourself you need to install the requirements for t
 
 #### Installation
 
-I'm using `nasm` and `lighttpd` which can be installed with `apt install nasm lighttpd -y`.
+`nasm` and `algernon` can be installed with `pacman -S nasm algernon` on Arch Linux, or `apt install nasm golang; go install github.com/xyproto/algernon@latest` on Debian / Ubuntu. Remember to add `~/go/bin` to the `PATH` if you use this method.
 
 #### Building
 
@@ -90,7 +90,7 @@ And so does this arbitrary sequence of emojis: 👩🏼‍❤️‍💋‍👨�
 <details>
   <summary>Hex</summary>
   <br/>
-    
+
 ```
 c53000b80000cd108b3f8d22e54021c3fe07bbd00778f5e4606bc00ad414d
 5449801c739df73dc301d79d8ad893a7bdcc607fa83eb5079f85b202779d5

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -1,4 +1,0 @@
-server.document-root = "PWD/demo"
-server.port = 3000
-index-file.names = ( "index.html" )
-mimetype.assign = ( ".html" => "text/html" )

--- a/main.sh
+++ b/main.sh
@@ -2,6 +2,4 @@
 set -e
 nasm -f bin snake.asm -o snake.com
 zip demo/snake.zip snake.com
-config=$(mktemp)
-sed "s/PWD/${PWD//\//\\\/}/" lighttpd.conf > "$config"
-lighttpd -D -f "$config" || rm "$config"
+algernon -t -n demo/


### PR DESCRIPTION
* `sed` in `main.sh` did not work on macOS.
* The lighttpd configuration is not needed if Algernon is used instead (available both in Homebrew and Pacman, and relatively straightforward to install on Ubuntu/Debian/other distros too).
* Also update `.gitignore`.

It's understandable if the move to Algernon is controversial, but I think it could make it easier for many users to try out the snake game locally, since sed + lighttpd.conf would no longer be needed.